### PR TITLE
Switch submodule to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "accelerator-web-ui-template"]
 	path = accelerator-web-ui-template
-	url = git@github.com:snowplow-incubator/accelerator-web-ui-template.git
+	url = https://github.com/snowplow-incubator/accelerator-web-ui-template.git

--- a/README.md
+++ b/README.md
@@ -1,4 +1,27 @@
 # Snowplow Accelerator Template
+
 This is a template for a Snowplow accelerator. Instructions on set up can be viewed [here](https://docs.snowplow.io/accelerators/template/)
 
+## Installation
 
+Recursively update the git submodules:
+
+```sh
+git submodule update --init --recursive
+```
+
+To build the Hugo app:
+
+```sh
+./scripts/build.sh build
+```
+
+## Usage
+
+To start an HTTP server serving the app, use:
+
+```sh
+./scripts/build.sh serve
+```
+
+This will run `hugo server` on the background.


### PR DESCRIPTION
When we use git@ this uses ssh to clone the submodule but Netlify doesn't like this (because it can't clone it via ssh).

Tested this theory here: https://github.com/snowplow/marketing-attribution-accelerator/pull/1

I've also added the build instructions to the README, so when its used as a Template the README already has those instructions in place.