### PR TITLE
Make external links open up on a new tab

### DIFF
--- a/_markup/render-link.html
+++ b/_markup/render-link.html
@@ -1,0 +1,1 @@
+<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if or (strings.HasPrefix .Destination "http") (strings.HasPrefix .Destination "https") }} target="_blank"{{ end }} >{{ .Text | safeHTML }}</a>


### PR DESCRIPTION
## Description & motivation

There has been a new request to change the default behaviour of Hugo and open any external links on a new tab. I found the [following](https://digitaldrummerj.me/hugo-links-to-other-pages/), which I implemented locally using the consent-accelerator, which worked fine. After agreeing with Craig it was decided we should set this as a default behaviour for all accelerators, hence the PR so that we can fit this into the current template review and modification process.

I was not sure, however how to apply this change as it needs to belong under layouts/_default, which is currently untracked and I suspect it is a submodule behaviour that I did not want to mess up, hence the push to the root folder temporarily as I know you will know how to handle this. 
